### PR TITLE
Add Polyfill for Node 6 Compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,29 @@ const SerializerJsonPlugin = require('./lib/SerializerJsonPlugin');
 
 const hardSourceVersion = require('./package.json').version;
 
+
+/*
+ * Add a String.prototype.padStart polyfill for node 6 compatability
+ * https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
+ */
+if (!String.prototype.padStart) {
+  String.prototype.padStart = function padStart(targetLength,padString) {
+    targetLength = targetLength>>0; //truncate if number or convert non-number to 0;
+    padString = String((typeof padString !== 'undefined' ? padString : ' '));
+    if (this.length > targetLength) {
+      return String(this);
+    }
+    else {
+      targetLength = targetLength-this.length;
+      if (targetLength > padString.length) {
+        padString += padString.repeat(targetLength/padString.length); //append to original to ensure we are longer than needed
+      }
+      return padString.slice(0,targetLength) + String(this);
+    }
+  };
+}
+
 function requestHash(request) {
   return crypto
     .createHash('sha1')


### PR DESCRIPTION
The current version of hard-source-webpack-plugin is not compatible with node 6 (see mzgoddard/hard-source-webpack-plugin), but contains important bug fixes. To generate the branch that can be used in Provider (0.8.1-node6), I've added a polyfill for String.prototype.padStart and run the code though babel.

Here are the steps I took to generate a version of 0.8.1 that is compatible with our version of node:
1. Add polyfill
1. Run code through babel with our BABEL_CONFIG_SERVER settings
1. Push the babel-ified code to a new branch (0.8.1-node6) and published a release from this branch

See: https://github.com/captain401/provider/pull/5304